### PR TITLE
Fix/segment delimiter

### DIFF
--- a/src/static/version/parser/hl7Parser.ts
+++ b/src/static/version/parser/hl7Parser.ts
@@ -20,7 +20,7 @@ export class Hl7Parser {
   }
 
   private static splitSegments(rawMessage: string): RawSegment[] {
-    return rawMessage.split("\n").map((segment) => this.splitSegment(segment));
+    return rawMessage.split(/(\n|<cr>)/).map((segment) => this.splitSegment(segment));
   }
 
   private static splitSegment(rawSegment: string): RawSegment {


### PR DESCRIPTION
---
🧯 Bugfix
---

This PR enables using HL7 specific delimiter `<cr>`  to seperate segments in hl7 messages

### 🚒 Technical Solution
- [ ] use regex in `Hl7Parser.splitSegments`

